### PR TITLE
Fix version comparison

### DIFF
--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -34,7 +34,7 @@ jobs:
           eval $(opam env)
           opam update
           opam upgrade
-          opam install opam-file-format yojson core dune
+          opam install opam-file-format opam-core yojson core dune
           opam install satyrographos-snapshot-stable || true # workaround
           satyrographos install
           rm -rf docs

--- a/dune
+++ b/dune
@@ -1,3 +1,3 @@
 (executable
   (name pkgjson)
-  (libraries str yojson opam-file-format unix core))
+  (libraries str yojson opam-file-format opam-core unix core))

--- a/pkgjson.ml
+++ b/pkgjson.ml
@@ -53,7 +53,7 @@ let get_package_list () =
 let get_version_list name =
   let pkgname_part_len = String.length (name ^ ".") in
   let dirs = Sys.readdir (Filename.concat package_root name) |> Array.to_list in
-  List.map (remove_head pkgname_part_len) dirs |> List.sort (fun a b -> String.compare b a)
+  List.map (remove_head pkgname_part_len) dirs |> List.sort (fun a b -> OpamVersionCompare.compare b a)
 
 let get_package_type name =
   let open Str in


### PR DESCRIPTION
This PR fixes #8 by using OpamVersionCompare.compare function to compare debian version strings.